### PR TITLE
add 3 new styles for mobile: .url, .hide-on-mobile and .show-on-mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,6 +66,13 @@ p,dl,h1,h2,h4,h5,h6,ol,pre,table,address,fieldset,figure{ margin-bottom:20px}
 form .actions											{ border:0px}
 div.submit, p.button									{ margin:10px 0px}
 .shade1, .shade2										{ margin-bottom:5px; padding:1px; background:url("../../dressprow/images/header-bg.gif") repeat-x scroll 0 0}
+.show-on-mobile                                         {display:none}
+
+@media only screen and (max-width: 767px){
+    .url                                                {overflow: hidden;text-overflow: ellipsis;white-space: nowrap;display: inline-block;max-width: 170px}
+    .hide-on-mobile                                     {display:none}
+    .show-on-mobile                                     {display:inherit}
+}
 
 
 /******************************* 2. STRUCTURE DIVS */


### PR DESCRIPTION
This just add 3 styles to css file. Actually they are not assigned to any element, so you will not see any change. 

.url style:
If you assign the .url class to a html text element, for example "a" or "span" or "li", this sytle will limit the width of this particular element to 170px on screens smaller than 768px, adding "..." at the end.

.hide-on-mobile style:
if you assign the .hide-on-mobile class to any html element, for example a table, this element will NOT be visible on screens smaller than 768px.

.show-on-mobile style:
if you assign the .show-on-mobile class to any html element, for example a "p", this elemente will ONLY be visible on screens smaller than 768px.

So, with this last 2 styles, you can hide tables with very complex information, with too many columns, and that is not relevant for use phplist in a mobile device, like the table to check the db structure,  and add a paragraph there with the leyend "This information is not available on mobile devices". So on desktop you will see the table and on mobile you will see the leyend.