### PR TITLE
disables "current" link in webblertabs menu to fix touch screens bug.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -186,15 +186,15 @@ div.notes, a.footnote 									{ font-size: 10px; vertical-align: super; }
 div.dropButton											{ width:190px; position:relative; padding:5px 5px 5px 10px; margin:10px 10px 10px 0px; background:url('../../dressprow/images/menuarrow.png') 180px 3px no-repeat; border-width:1px; border-style:solid; -webkit-border-radius:8px; -moz-border-radius:8px; border-radius:8px; font-size:15px; line-height:15px; font-variant:small-caps; clear:both}
 div.dropButton a img.arrow								{ display:none}
 div.dropButton .submenu a 								{ line-height:12px; padding:7px; margin-top:5px; width:175px; font-size:13px; border-top-width:1px; border-top-style:dotted; display:inline-block; -webkit-border-radius:8px; -moz-border-radius:8px; border-radius:8px}
-#webblertabs											{ width:200px; position:relative; margin:10px 10px 10px 0px; background:url('../../dressprow/images/menuarrow.png') 175px 3px no-repeat; border-width:1px; border-style:solid; -webkit-border-radius:8px; -moz-border-radius:8px; border-radius:8px}
-#webblertabs ul											{ padding-top:2px !important; list-style:none}
+#webblertabs											{ min-height:28px;width:200px; position:relative; margin:10px 10px 10px 0px; background:url('../../dressprow/images/menuarrow.png') 170px 3px no-repeat; border-width:1px; border-style:solid; -webkit-border-radius:8px; -moz-border-radius:8px; border-radius:8px}
+#webblertabs ul											{ width:170px; margin:0px;padding:0px 0px; list-style:none;position:absolute;clear:both; font-size:15px; line-height:15px; border: 1px solid #CCC;border-radius: 8px;background:rgba(250,250,250,0.95)}
+.minitabs #webblertabs ul                               {position:relative}
 #webblertabs ul li										{ margin-left:2px; padding:0px}
 #webblertabs ul li a									{ padding:1px 10px !important; width:150px; overflow:hidden}
 div.dropButton .submenu a:hover 						{ margin-top:5px}
-#webblertabs ul, #webblertabs ul li,
-#webblertabs ul li a 									{ width:170px; margin:0px; padding:1px 0px; border:none; clear:both; font-size:15px; line-height:15px; -webkit-border-radius:6px; -moz-border-radius:6px; border-radius:6px}
+#webblertabs ul li, #webblertabs ul li a                { width:170px; margin:0px; padding:1px 0px; border:none; clear:both; font-size:15px; line-height:15px; -webkit-border-radius:6px; -moz-border-radius:6px; border-radius:6px}
 #webblertabs ul li:hover,
-div.dropButton .submenu a:hover							{ border-width:1px; border-style:solid} 
+div.dropButton .submenu a:hover							{ border:0} 
 
 /* minitabs (webblertabs inside "minitabs" div)  */
 .minitabs                                               { margin:0px auto 5px;padding:0px}

--- a/js/phplist.js
+++ b/js/phplist.js
@@ -98,6 +98,8 @@ $(document).ready(function() {
         $(this).find('ul li').hide();
         $(this).find('ul li.current').show();
     });
+    $('#webblertabs .current a').click(function () {return false;});
+    
     $('#webblertabs').hover(function(){
         $(this).find('ul li').slideDown();
     },


### PR DESCRIPTION
I can't check if this works, because i cant access to my local dev site by smartphone. It does what it sais: In the "webblertabs" menu, like the one is in page http://dev.phplist.com/lists/admin/?page=list
this change disables the "current" link in the menu, to avoid click make the "hover" action in 
touchscreens.

Need to minify js to apply the change.

---------
The second commit change the style of webblertabs menu to not push content down (see screenshots)
BEFORE:
![screen shot 2016-03-06 at 22 01 45](https://cloud.githubusercontent.com/assets/7660111/13558724/864937fe-e3e8-11e5-925b-28339e6b9aa1.png)

AFTER:
![screen shot 2016-03-06 at 22 01 38](https://cloud.githubusercontent.com/assets/7660111/13558717/60883ba0-e3e8-11e5-9024-db9930616955.png)
