### PR TITLE
Improve Onyx RSS error handling

### DIFF
--- a/onyx-rss.php
+++ b/onyx-rss.php
@@ -311,14 +311,17 @@ class ONYX_RSS
 
    //private function raiseError($line, $err)
 
-   public function raiseError($line, $err)
-   {
-       if ($this->conf['debug_mode']) {
-           printf($this->conf['error'], $line, $err);
-       } else {
-           $this->lasterror = $err;
-       }
-   }
+    public function raiseError($line, $err)
+    {
+        if ($this->conf['debug_mode']) {
+            // Format error message
+            $errorMsg = sprintf( $this->conf['error'], $line, $err );
+            // Raise phpList error
+            Error( $errorMsg );
+        } else {
+            $this->lasterror = $err;
+        }
+    }
 
     public function setCachePath($path)
     {

--- a/rssfeed.php
+++ b/rssfeed.php
@@ -19,7 +19,12 @@ if (
 include dirname(__FILE__).'/onyx-rss.php';
 
 $rss = new ONYX_RSS();
-$rss->setDebugMode(false);
+
+// Disable debugging output unless we are running in test mode
+if( ! TEST ) {
+    $rss->setDebugMode(false);
+}
+
 $rss->setCachePath($GLOBALS['tmpdir']);
 // Set expiry time to 24hrs (sets $rss->conf['cache_time'])
 $rss->setExpiryTime(1440);

--- a/rssfeed.php
+++ b/rssfeed.php
@@ -1,50 +1,60 @@
 <?php
 
-if (true || !isset($_GET['page']) || (isset($_GET['page']) && in_array($_GET['page'], array('home', 'about', 'dashboard', 'community','login')))) {
-    $news = '';
+// Initialise var for holding news items HTML
+$news = '';
 
-    $max = 10;
-    if (empty($_SESSION['adminloggedin']) ) {
-      $max = 3; // show last 3 only on login page
-    } elseif (isset($_GET['page']) && !in_array($_GET['page'], array('home', 'about', 'dashboard', 'community','login'))) {
-      $max = 3; // only 3 on most pages
-    }
-    include dirname(__FILE__).'/onyx-rss.php';
-    $rss = new ONYX_RSS();
-    $rss->setDebugMode(false);
-    $rss->setCachePath($GLOBALS['tmpdir']);
-    $rss->setExpiryTime(1440);
-    $parseresult = $rss->parse('https://www.phplist.org/newslist/feed/', 'phplistnews');
-    $count = 0;
-    if ($parseresult) {
-        while ($item = $rss->getNextItem()) {
-            $count++;
-            if ($count > $max) break;
-            $date = $item['pubdate'];
-            $date = str_replace('00:00:00 +0000', '', $date);
-            $date = str_replace('00:00:00 +0100', '', $date);
-            $date = str_replace('+0000', '', $date);
-            if (preg_match('/\d+:\d+:\d+/', $date, $regs)) {
-                $date = str_replace($regs[0], '', $date);
-            }
+// Set maximum number of news items to display
+$max = 10;
 
-            ## remove the '<p>&nbsp;</p>' in the descriptions
-            $desc = $item['description'];
-            $desc = str_replace('<p>&nbsp;</p>', '', $desc);
-            $desc = '';
+// Show fewer news items for certain pages
+if (
+    empty($_SESSION['adminloggedin'])
+    || (isset($_GET['page']) && !in_array($_GET['page'], array('home', 'about', 'dashboard', 'community','login')))
+    ) {
+    // Reduce max news items count
+    $max = 3;
+}
 
-            $news .= '<li>
-      <div class="publisheddate">'.$date.'</div> <a href="'.$item['link'].'?utm_source=phplist-'.VERSION.'&utm_medium=newspanel&utm_content='.urlencode($item['title']).'&utm_campaign=newspanel" target="_blank">'.$item['title'].'</a>
-      '.$desc.'
-      </li>';
+// Load Onxy RSS class file
+include dirname(__FILE__).'/onyx-rss.php';
+
+$rss = new ONYX_RSS();
+$rss->setDebugMode(false);
+$rss->setCachePath($GLOBALS['tmpdir']);
+// Set expiry time to 24hrs (sets $rss->conf['cache_time'])
+$rss->setExpiryTime(1440);
+// Parse the RSS feed
+$parseresult = $rss->parse('https://www.phplist.org/newslist/feed/', 'phplistnews');
+// Set the counter to zero
+$count = 0;
+if ($parseresult) {
+    while ($item = $rss->getNextItem()) {
+        $count++;
+        if ($count > $max) break;
+        $date = $item['pubdate'];
+        $date = str_replace('00:00:00 +0000', '', $date);
+        $date = str_replace('00:00:00 +0100', '', $date);
+        $date = str_replace('+0000', '', $date);
+        if (preg_match('/\d+:\d+:\d+/', $date, $regs)) {
+            $date = str_replace($regs[0], '', $date);
         }
-    }
 
-    if (!empty($news)) {
-        print '<div id="newsfeed" class="menutableright block">';
-        print '
-       <h3>'.s('phpList community news').'</h3>
-        <ul>'.$news.'</ul>';
-        print '</div>';
+        ## remove the '<p>&nbsp;</p>' in the descriptions
+        $desc = $item['description'];
+        $desc = str_replace('<p>&nbsp;</p>', '', $desc);
+        $desc = '';
+
+        $news .= '<li>
+    <div class="publisheddate">'.$date.'</div> <a href="'.$item['link'].'?utm_source=phplist-'.VERSION.'&utm_medium=newspanel&utm_content='.urlencode($item['title']).'&utm_campaign=newspanel" target="_blank">'.$item['title'].'</a>
+    '.$desc.'
+    </li>';
     }
+}
+
+if (!empty($news)) {
+    print '<div id="newsfeed" class="menutableright block">';
+    print '
+    <h3>'.s('phpList community news').'</h3>
+    <ul>'.$news.'</ul>';
+    print '</div>';
 }

--- a/rssfeed.php
+++ b/rssfeed.php
@@ -9,7 +9,7 @@ $max = 10;
 // Show fewer news items for certain pages
 if (
     empty($_SESSION['adminloggedin'])
-    || (isset($_GET['page']) && !in_array($_GET['page'], array('home', 'about', 'dashboard', 'community','login')))
+    || isset($_GET['page']) && !in_array($_GET['page'], array('home', 'about', 'dashboard', 'community','login'))
     ) {
     // Reduce max news items count
     $max = 3;
@@ -39,7 +39,7 @@ if ($parseresult) {
             $date = str_replace($regs[0], '', $date);
         }
 
-        ## remove the '<p>&nbsp;</p>' in the descriptions
+        // remove the '<p>&nbsp;</p>' in the descriptions
         $desc = $item['description'];
         $desc = str_replace('<p>&nbsp;</p>', '', $desc);
         $desc = '';


### PR DESCRIPTION
Enable Onyx RSS debug mode and therefore error reporting when phpList TEST mode is enabled, and use phpList error printing for those errors when they arise (instead of merely printing direct to browser).