### PR TITLE
Stop retrying when rss news feed does not respond

### DIFF
--- a/rssfeed.php
+++ b/rssfeed.php
@@ -84,5 +84,8 @@ $parseresult = $rss->parse('https://www.phplist.org/newslist/feed/', 'phplistnew
 if ($parseresult) {
     $_SESSION['news']['short'] = buildNews($rss, 3);
     $_SESSION['news']['long'] = buildNews($rss, 10);
-    echo $_SESSION['news'][$newsSize];
+} else {
+    $_SESSION['news']['short'] = '';
+    $_SESSION['news']['long'] = '';
 }
+echo $_SESSION['news'][$newsSize];


### PR DESCRIPTION
The rss feed at https://www.phplist.org/newslist/feed/ is still unreliable. Currently the code caches the feed content in the php session, but when the feed is not responding then each page load is affected by having to keep retrying.

This change simply caches empty strings when the feed does not respond. The feed won't be tried again until the admin logs-out, therefore all subsequent pages will not display the news sidebar.

Just now the feed was taking more than 35s to respond
![screenshot_2016-10-29_08-57-23](https://cloud.githubusercontent.com/assets/3147688/19828120/c7375354-9db5-11e6-96f1-8bd6ae144231.png)
